### PR TITLE
Fix missing const keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 *.exe
 *.out
 *.app
+test/expected.t

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ before_install:
 
 script:
   - $CXX --version
-  - cd ~/build/martinmoene/expected-lite/test
+  - cd test
   - $CXX -Wall -Wextra -std=c++11 -Wno-unused-parameter -Dlest_FEATURE_AUTO_REGISTER=1 -I../include/nonstd -o expected.t expected.t.cpp && ./expected.t && ./expected.t --list-tests

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ unexpected_type<>: Allows to observe its value, std::exception_ptr specializatio
 unexpected_type<>: Allows to modify its value
 unexpected_type<>: Allows to modify its value, std::exception_ptr specialization
 unexpected_type<>: Provides relational operators
-unexpected_type<>: Supports relational operators, std::exception_ptr specialization
+unexpected_type<>: Provides relational operators, std::exception_ptr specialization
 is_unexpected<X>: Is true for unexpected_type
 is_unexpected<X>: Is false for non-unexpected_type (int)
 make_unexpected(): Allows to create an unexpected_type<E> from an E
@@ -307,13 +307,11 @@ expected<>: Allows to move-construct from unexpected_type<>
 expected<>: Allows to in-place-construct unexpected_type<>
 expected<>: Allows to copy-assign from expected<>
 expected<>: Allows to move-assign from expected<>
-expected<>: Allows to copy-assign from unexpected_type<>
-expected<>: Allows to move-assign from unexpected_type<>
 expected<>: Allows to copy-assign from type convertible to value_type
 expected<>: Allows to move-assign from type convertible to value_type
-expected<>: Allows to emplace a value_type
 expected<>: Allows to be swapped
 expected<>: Allows to observe its value via a pointer
+expected<>: Allows to observe its value via a pointer to constant
 expected<>: Allows to modify its value via a pointer
 expected<>: Allows to observe its value via a reference
 expected<>: Allows to observe its value via a r-value reference

--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -114,7 +114,7 @@ private:
         return std::move( m_value );
     }
 
-    value_type * value_ptr() const
+    value_type const * value_ptr() const
     {
         return &m_value;
     }

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -589,6 +589,14 @@ CASE( "expected<>: Allows to observe its value via a pointer" )
     EXPECT( ei->member == value );
 }
 
+CASE( "expected<>: Allows to observe its value via a pointer to constant" )
+{
+    auto const value = 7;
+    const expected<Composite> ei{ Composite{value} };
+
+    EXPECT( ei->member == value );
+}
+
 CASE( "expected<>: Allows to modify its value via a pointer" )
 {
     auto const old_value = 3;

--- a/test/expected.t.cpp
+++ b/test/expected.t.cpp
@@ -579,16 +579,25 @@ CASE( "expected<>: Allows to be swapped" )
 
 // expected<> observers
 
+struct Composite { int member; };
+
 CASE( "expected<>: Allows to observe its value via a pointer" )
 {
     auto const value = 7;
-    expected<int> ei{ value };
-    
-//    EXPECT( *( ei-> ) == value );
+    expected<Composite> ei{ Composite{value} };
+
+    EXPECT( ei->member == value );
 }
 
 CASE( "expected<>: Allows to modify its value via a pointer" )
 {
+    auto const old_value = 3;
+    auto const new_value = 7;
+    expected<Composite> ei{ Composite{old_value} };
+
+    ei->member = new_value;
+
+    EXPECT( ei->member == new_value );
 }
 
 CASE( "expected<>: Allows to observe its value via a reference" )


### PR DESCRIPTION
There was a missing `const` in `storage_t::operator->() const`'s return type. This PR fixes that issue and adds some tests for `operator->()`. Please merge.