### PR TITLE
Fix value bug.

### DIFF
--- a/include/nonstd/expected.hpp
+++ b/include/nonstd/expected.hpp
@@ -39,7 +39,10 @@
     typename std::enable_if<__VA_ARGS__, void*>::type = 0
 
 #define nsel_REQUIRES_0(...) \
-    template< bool B = (__VA_ARGS__), typename std::enable_if<B, int>::type = 0 >
+  template <bool B = (__VA_ARGS__), typename std::enable_if<B, int>::type = 0>
+
+#define nsel_REQUIRES_1(...) \
+  template <int B = (__VA_ARGS__), typename std::enable_if<B, int>::type = 0>
 
 #define nsel_REQUIRES_T(...) \
     typename = typename std::enable_if< (__VA_ARGS__), nonstd::expected_detail::enabler >::type
@@ -649,31 +652,61 @@ public:
         return has_value_;
     }
 
+    nsel_REQUIRES_0(!std::is_same<E, std::exception_ptr>::value)
+
     constexpr value_type const & value() const &
     {
-        return has_value()
-            ? contained.value()
-            : std::is_same<error_type, std::exception_ptr>::value
-            ? ( std::rethrow_exception( contained.error() ), contained.value() )
-            : ( throw bad_expected_access<error_type>( contained.error() ), contained.value() );
+      return has_value()
+                 ? contained.value()
+                 : (throw bad_expected_access<error_type>(contained.error()),
+                    contained.value());
     }
+
+    nsel_REQUIRES_1(std::is_same<E, std::exception_ptr>::value)
+
+    constexpr value_type const & value() const &
+    {
+      return has_value() ? contained.value()
+                         : (std::rethrow_exception(contained.error()),
+                            contained.value());
+    }
+
+    nsel_REQUIRES_0(!std::is_same<E, std::exception_ptr>::value)
 
     value_type & value() &
     {
-        return has_value()
-            ? contained.value()
-            : std::is_same<error_type, std::exception_ptr>::value
-            ? ( std::rethrow_exception( contained.error() ), contained.value() )
-            : ( throw bad_expected_access<error_type>( contained.error() ), contained.value() );
+      return has_value()
+                 ? contained.value()
+                 : (throw bad_expected_access<error_type>(contained.error()),
+                    contained.value());
     }
+
+    nsel_REQUIRES_1(std::is_same<E, std::exception_ptr>::value)
+
+    value_type & value() &
+    {
+      return has_value() ? contained.value()
+                         : (std::rethrow_exception(contained.error()),
+                            contained.value());
+    }
+
+    nsel_REQUIRES_0(!std::is_same<E, std::exception_ptr>::value)
 
     constexpr value_type && value() &&
     {
-        return has_value()
-            ? std::move( contained.value() )
-            : std::is_same<error_type, std::exception_ptr>::value
-            ? ( std::rethrow_exception( contained.error() ), contained.value() )
-            : ( throw bad_expected_access<error_type>( contained.error() ), contained.value() );
+      return has_value()
+                 ? std::move(contained.value())
+                 : (throw bad_expected_access<error_type>(contained.error()),
+                    contained.value());
+    }
+
+    nsel_REQUIRES_1(std::is_same<E, std::exception_ptr>::value)
+
+    constexpr value_type && value() &&
+    {
+      return has_value() ? std::move(contained.value())
+                         : (std::rethrow_exception(contained.error()),
+                            contained.value());
     }
 
     constexpr error_type const & error() const &
@@ -1253,6 +1286,7 @@ struct hash< nonstd::expected<void,E> >
 
 #undef nsel_REQUIRES
 #undef nsel_REQUIRES_0
+#undef nsel_REQUIRES_1
 #undef nsel_REQUIRES_T
 
 #endif // NONSTD_EXPECTED_LITE_HPP


### PR DESCRIPTION
Uses `std::enable_if` specializations for `expected::value` instead of `if` statements.

Fixes #15 